### PR TITLE
[Feat] AI 일기 생성 페이지 위치 추적 통합 및 펫 목록 실시간 연동

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,8 @@
 import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Outlet,
+    BrowserRouter as Router,
+    Routes,
+    Route,
+    Outlet,
 } from "react-router-dom";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -72,88 +72,88 @@ import HomePage from "@/features/home/components/HomePage"
 const queryClient = new QueryClient();
 
 const AppLayout = () => {
-  return (
-    <>
-      <Header />
-      <main className="bg-background text-foreground">
-        <Outlet />
-      </main>
-      <FloatingChatbotWidget />
-    </>
-  );
+    return (
+        <>
+            <Header />
+            <main className="bg-background text-foreground">
+                <Outlet />
+            </main>
+            <FloatingChatbotWidget />
+        </>
+    );
 };
 
 function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <Router>
-        <ThemeProvider>
-          <AuthProvider>
-            <CartProvider>
-              <WishlistProvider>
-                <Routes>
-                  <Route path="/" element={<AppLayout />}>
-                    <Route index element={<HomePage />} />
-                    <Route path="dashboard" element={<DashboardPage />} />
-                    <Route path="feed" element={<FeedPage />} />
-                    <Route path="feed/ai-recommend" element={<FeedAiRecommendPage />} />
-                    {/* feed/create 라우트 삭제 */}
-                    <Route path="create" element={<CreatePage />} />
-                    <Route path="ai-diary" element={<AiDiaryPage />} />
-                    <Route path="ai-studio" element={<AiStudioPage />} />
-                    <Route path="ai-studio/diary" element={<AiDiaryPage />} />
-                    <Route path="ai-studio/recap" element={<AiRecapPage />} />
-                    <Route
-                      path="ai-studio/biography"
-                      element={<AiBiographyPage />}
-                    />
-                    <Route path="chatbot" element={<ChatbotPage />} />
-                    <Route path="gallery" element={<GalleryPage />} />
-                    <Route path="healthcare" element={<HealthcarePage />} />
-                    <Route path="messages" element={<MessagesPage />} />
-                    <Route
-                      path="missing-pet/register"
-                      element={<MissingPetRegisterPage />}
-                    />
-                    <Route path="pet-mate" element={<PetMatePage />} />
-                    <Route path="portfolio" element={<PortfolioPage />} />
-                    <Route path="profile" element={<ProfilePage />}>
-                      <Route path="mileage" element={<MileagePage />} />
-                    </Route>
-                    <Route path="profile/pet/:id" element={<PetProfilePage />} />
-                    <Route path="profile/pet/:id/edit" element={<PetEditPage />} />
-                    <Route path="shop" element={<ShopPage />}>
-                      <Route path="cart" element={<CartPage />} />
-                      <Route path="wishlist" element={<WishlistPage />} />
-                      <Route path="product/:id" element={<ProductDetailPage />} />
-                      <Route path="checkout" element={<CheckoutPage />}>
-                        <Route
-                          path="complete"
-                          element={<CheckoutCompletePage />}
-                        />
-                      </Route>
-                    </Route>
-                    <Route path="user/:id" element={<UserPage />} />
-                  </Route>
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route path="/onboarding" element={<OnboardingPage />} />
-                  <Route path="/pet-info" element={<PetInfoPage />} />
-                  <Route path="/register-pet" element={<RegisterPetPage />} />
-                  <Route path="/settings" element={<SettingsPage />} />
-                  <Route path="/signup" element={<SignupPage />}>
-                    <Route index element={<SignupIndexPage />} />
-                    <Route path="info" element={<SignupInfoPage />} />
-                  </Route>
-                  <Route path="/user-info" element={<UserInfoPage />} />
-                  <Route path="/welcome" element={<WelcomePage />} />
-                </Routes>
-              </WishlistProvider>
-            </CartProvider>
-          </AuthProvider>
-        </ThemeProvider>
-      </Router>
-    </QueryClientProvider>
-  );
+    return (
+        <QueryClientProvider client={queryClient}>
+            <Router>
+                <ThemeProvider>
+                    <AuthProvider>
+                        <CartProvider>
+                            <WishlistProvider>
+                                <Routes>
+                                    <Route path="/" element={<AppLayout />}>
+                                        <Route index element={<HomePage />} />
+                                        <Route path="dashboard" element={<DashboardPage />} />
+                                        <Route path="feed" element={<FeedPage />} />
+                                        <Route path="feed/ai-recommend" element={<FeedAiRecommendPage />} />
+                                        {/* feed/create 라우트 삭제 */}
+                                        <Route path="create" element={<CreatePage />} />
+                                        <Route path="ai-diary" element={<AiDiaryPage />} />
+                                        <Route path="ai-studio" element={<AiStudioPage />} />
+                                        <Route path="ai-studio/diary" element={<AiDiaryPage />} />
+                                        <Route path="ai-studio/recap" element={<AiRecapPage />} />
+                                        <Route
+                                            path="ai-studio/biography"
+                                            element={<AiBiographyPage />}
+                                        />
+                                        <Route path="chatbot" element={<ChatbotPage />} />
+                                        <Route path="gallery" element={<GalleryPage />} />
+                                        <Route path="healthcare" element={<HealthcarePage />} />
+                                        <Route path="messages" element={<MessagesPage />} />
+                                        <Route
+                                            path="missing-pet/register"
+                                            element={<MissingPetRegisterPage />}
+                                        />
+                                        <Route path="pet-mate" element={<PetMatePage />} />
+                                        <Route path="portfolio" element={<PortfolioPage />} />
+                                        <Route path="profile" element={<ProfilePage />}>
+                                            <Route path="mileage" element={<MileagePage />} />
+                                        </Route>
+                                        <Route path="profile/pet/:id" element={<PetProfilePage />} />
+                                        <Route path="profile/pet/:id/edit" element={<PetEditPage />} />
+                                        <Route path="shop" element={<ShopPage />}>
+                                            <Route path="cart" element={<CartPage />} />
+                                            <Route path="wishlist" element={<WishlistPage />} />
+                                            <Route path="product/:id" element={<ProductDetailPage />} />
+                                            <Route path="checkout" element={<CheckoutPage />}>
+                                                <Route
+                                                    path="complete"
+                                                    element={<CheckoutCompletePage />}
+                                                />
+                                            </Route>
+                                        </Route>
+                                        <Route path="user/:id" element={<UserPage />} />
+                                    </Route>
+                                    <Route path="/login" element={<LoginPage />} />
+                                    <Route path="/onboarding" element={<OnboardingPage />} />
+                                    <Route path="/pet-info" element={<PetInfoPage />} />
+                                    <Route path="/register-pet" element={<RegisterPetPage />} />
+                                    <Route path="/settings" element={<SettingsPage />} />
+                                    <Route path="/signup" element={<SignupPage />}>
+                                        <Route index element={<SignupIndexPage />} />
+                                        <Route path="info" element={<SignupInfoPage />} />
+                                    </Route>
+                                    <Route path="/user-info" element={<UserInfoPage />} />
+                                    <Route path="/welcome" element={<WelcomePage />} />
+                                </Routes>
+                            </WishlistProvider>
+                        </CartProvider>
+                    </AuthProvider>
+                </ThemeProvider>
+            </Router>
+        </QueryClientProvider>
+    );
 }
 
 export default App;

--- a/src/features/diary/components/LocationTracker.tsx
+++ b/src/features/diary/components/LocationTracker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 
 // 백엔드 API 주소
-const BASE_URL = 'http://localhost:8087/api';
+const BASE_URL = 'http://localhost:8000/api';
 
 // [중요] 토큰 가져오기 (petlog_token 우선, 없으면 accessToken 확인)
 const getAccessToken = () => localStorage.getItem('petlog_token') || localStorage.getItem('accessToken');

--- a/src/features/diary/pages/AiDiaryPage.tsx
+++ b/src/features/diary/pages/AiDiaryPage.tsx
@@ -6,6 +6,7 @@ import {
   Save, BookOpen, PawPrint, Sun, Smile, MapPin
 } from 'lucide-react';
 import { createRoot } from 'react-dom/client';
+import { getUserApi } from "@/features/auth/api/auth-api";
 // [중요] LocationTracker import (파일 경로에 맞게 수정해주세요)
 import LocationTracker from '../components/LocationTracker';
 // 만약 같은 파일에 넣으셨다면 import 필요 없음
@@ -54,18 +55,25 @@ const useAuth = () => {
         const userId = Number(payload.userId || payload.sub || payload.id);
 
         if (!isNaN(userId)) {
-          const petsFromToken = payload.pets || [
-            { id: 1, name: '초코', species: '강아지', breed: '푸들', gender: '남아', neutered: true, age: 3 },
-            { id: 2, name: '나비', species: '고양이', breed: '코숏', gender: '여아', neutered: false, age: 2 }
-          ];
-
-          setUser({
-            id: userId,
-            username: payload.username || payload.name || 'User',
-            pets: petsFromToken
-          });
-
-          console.log("[Auth] 사용자 인증 성공 (Local Parsing):", userId);
+          // [수정] API를 통해 최신 사용자 정보(펫 포함) 가져오기
+          getUserApi(userId)
+            .then((userData) => {
+              console.log("[Auth] 사용자 정보 조회 성공:", userData);
+              setUser({
+                id: userId,
+                username: userData.username || userData.social || 'User',
+                pets: userData.pets || [] // API에서 가져온 펫 목록 사용
+              });
+            })
+            .catch((err) => {
+              console.error("[Auth] 사용자 정보 조회 실패:", err);
+              // 실패 시 토큰 정보라도 사용 (Fallback)
+              setUser({
+                id: userId,
+                username: payload.username || payload.name || 'User',
+                pets: payload.pets || []
+              });
+            });
         }
       } catch (e) {
         console.error("[Auth] 토큰 파싱 실패:", e);
@@ -639,8 +647,8 @@ const AiDiaryPage = () => {
         content: "",
         visibility: "PRIVATE",
         isAiGen: true,
-        weather: "맑음",
-        mood: "행복",
+        weather: "",
+        mood: "",
         date: selectedDate,
         latitude: location ? location.lat : null,
         longitude: location ? location.lng : null,
@@ -720,7 +728,6 @@ const AiDiaryPage = () => {
           <button onClick={() => navigate(-1)} className="text-pink-600 hover:text-pink-700 transition-colors p-1"><ChevronLeft className="w-6 h-6" /></button>
           <h1 className="text-lg font-bold text-pink-600 md:text-xl">Pet Log AI</h1>
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-pink-500 hidden sm:block">{user?.username}</span>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## 관련 이슈

Closes #31 

---

## 기능 설명

- AI 일기 생성 페이지(AiDiaryPage)에서 사용자의 실시간 위치를 추적하여 DB에 저장하고, 일기 작성 시 과거 위치 이력을 조회하여 자동으로 입력하는 기능을 구현했습니다.
- 또한, 기존 토큰에 의존하던 펫 목록을 실시간 API 조회로 변경하여 마이페이지에서의 데이터 변경 사항이 즉시 반영되도록 개선했습니다.

---

## 상세 내용

### 1. 프론트엔드 (Frontend) - AiDiaryPage.tsx

- 컴포넌트 구조 개선 & 버그 수정

  - (추후 처리 예정) ReactDOM.createRoot 중복 호출 경고 해결 (root.render 제거 및 export default 처리)

- 펫 목록 실시간 동기화

  - 기존: JWT 토큰 내부의 고정된 Mock 데이터 사용

  - 변경: 페이지 진입 시 GET /api/pets/user/{userId}를 호출하여 DB의 최신 펫 목록 조회 (토큰 의존성 제거)

   - 로딩 상태(isLoadingPets) 및 펫이 없을 경우의 예외 처리 UI 추가

- 위치 정보 로직 고도화 (handleGenerate)

  - 오늘 날짜: 브라우저 GPS(navigator.geolocation)를 사용하여 실시간 좌표 획득

  - 과거 날짜: 백엔드 API (GET /api/locations/history)를 호출하여 PostGIS에 저장된 과거 이동 기록 조회

  - Fallback: 과거 기록이 없을 경우, 현재 위치를 대신 사용하거나 '위치 정보 없음'으로 처리

- API 요청 데이터 최적화

  - createAiDiary 요청 시 mood, weather 임의 값 제거 (백엔드 AI가 분석하여 생성하므로 프론트에서 임의 값 전송 불필요)

  - API Gateway 포트(8000)로 BASE_URL 통일

### 2. 백엔드 (Backend) 연동 사항

- 위치 정보 API

  - POST /api/locations: 20분 주기로 사용자 좌표 저장

   - GET /api/locations/history: 날짜별 대표 위치 조회

---

## 테스트 결과

- [x] 펫 목록: 마이페이지에서 펫 추가 후 일기 페이지 진입 시 즉시 리스트에 반영됨

- [x] 일기 생성: - 오늘 날짜: 현재 좌표로 생성됨

  - 과거 날짜: DB에 저장된 과거 좌표를 불러와서 생성됨

- [x] 에러 핸들링: 401(토큰 만료) 발생 시 로그아웃 및 로그인 페이지 이동 로직 동작 확인

## 📸 스크린샷 
<img width="389" height="318" alt="스크린샷 2025-12-18 오후 5 06 59" src="https://github.com/user-attachments/assets/eb0d2116-924f-44ca-8e04-08baf1721a06" />

<img width="239" height="209" alt="스크린샷 2025-12-18 오후 5 07 18" src="https://github.com/user-attachments/assets/e47a6f8c-abb6-4db5-b140-b76285ff6e27" />


## 💬 리뷰 요구사항

- 일기 생성 요청 시 mood, weather를  빈 값으로 보내도록 수정했습니다. 백엔드 로직과 호환되는지 확인 부탁드립니다.