### PR TITLE
PetMate 요청 취소 및 UI 개선

### DIFF
--- a/src/features/petmate/components/MatchingFriendsModal.tsx
+++ b/src/features/petmate/components/MatchingFriendsModal.tsx
@@ -16,6 +16,7 @@ interface MatchingFriendsModalProps {
     onAccept: (matchId: number) => Promise<MatchResult | null>;
     onReject: (matchId: number) => Promise<boolean>;
     onUnfriend: (matchedUserId: number) => Promise<boolean>;
+    onCancelRequest: (toUserId: number) => Promise<boolean>;
     onMatchSuccess: (result: MatchResult, request: PendingRequest) => void;
 }
 
@@ -28,6 +29,7 @@ export function MatchingFriendsModal({
     onAccept,
     onReject,
     onUnfriend,
+    onCancelRequest,
     onMatchSuccess
 }: MatchingFriendsModalProps) {
     const [activeTab, setActiveTab] = useState<TabType>('matched');
@@ -91,7 +93,7 @@ export function MatchingFriendsModal({
                         animate={{ scale: 1, opacity: 1 }}
                         exit={{ scale: 0.9, opacity: 0 }}
                         transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                        className="bg-white rounded-3xl shadow-2xl max-w-lg w-full max-h-[85vh] overflow-hidden"
+                        className="bg-white rounded-3xl shadow-2xl max-w-lg w-full h-[500px] flex flex-col overflow-hidden"
                         onClick={(e) => e.stopPropagation()}
                     >
                         {/* 헤더 */}
@@ -117,8 +119,8 @@ export function MatchingFriendsModal({
                                     key={tab.id}
                                     onClick={() => setActiveTab(tab.id)}
                                     className={`flex-1 py-3 px-4 text-sm font-medium transition-colors relative ${activeTab === tab.id
-                                            ? 'text-pink-600'
-                                            : 'text-gray-500 hover:text-gray-700'
+                                        ? 'text-pink-600'
+                                        : 'text-gray-500 hover:text-gray-700'
                                         }`}
                                 >
                                     <div className="flex items-center justify-center gap-1">
@@ -126,25 +128,22 @@ export function MatchingFriendsModal({
                                         <span>{tab.label}</span>
                                         {tab.count > 0 && (
                                             <span className={`ml-1 px-1.5 py-0.5 text-xs rounded-full ${activeTab === tab.id
-                                                    ? 'bg-pink-100 text-pink-600'
-                                                    : 'bg-gray-100 text-gray-500'
+                                                ? 'bg-pink-100 text-pink-600'
+                                                : 'bg-gray-100 text-gray-500'
                                                 }`}>
                                                 {tab.count}
                                             </span>
                                         )}
                                     </div>
                                     {activeTab === tab.id && (
-                                        <motion.div
-                                            layoutId="activeTab"
-                                            className="absolute bottom-0 left-0 right-0 h-0.5 bg-pink-500"
-                                        />
+                                        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-pink-500" />
                                     )}
                                 </button>
                             ))}
                         </div>
 
                         {/* 컨텐츠 */}
-                        <div className="overflow-y-auto max-h-[calc(85vh-180px)]">
+                        <div className="flex-1 overflow-y-auto">
                             {/* 매칭된 친구 탭 */}
                             {activeTab === 'matched' && (
                                 <div className="p-4">
@@ -308,9 +307,15 @@ export function MatchingFriendsModal({
                                                             <p className="text-sm text-gray-500">{request.fromUserName}</p>
                                                             <p className="text-xs text-orange-500 mt-1">응답 대기 중...</p>
                                                         </div>
-                                                        <div className="text-xs text-gray-400">
-                                                            {formatTime(request.createdAt)}
-                                                        </div>
+                                                        <Button
+                                                            onClick={() => onCancelRequest(request.fromUserId)}
+                                                            variant="outline"
+                                                            size="sm"
+                                                            className="text-red-500 border-red-200 hover:bg-red-50 text-xs"
+                                                        >
+                                                            <X className="h-3 w-3 mr-1" />
+                                                            취소
+                                                        </Button>
                                                     </div>
                                                 </div>
                                             ))}

--- a/src/features/petmate/components/SmoothScrollList.tsx
+++ b/src/features/petmate/components/SmoothScrollList.tsx
@@ -9,11 +9,12 @@ interface SmoothScrollCardProps {
     isLiked: boolean
     onLike: (e: React.MouseEvent) => void
     onClick: () => void
+    onScrollToCenter: () => void
     isActive: boolean
     position: 'prev2' | 'prev' | 'current' | 'next' | 'next2' | 'hidden'
 }
 
-export function SmoothScrollCard({ candidate, isLiked, onLike, onClick, isActive, position }: SmoothScrollCardProps) {
+export function SmoothScrollCard({ candidate, isLiked, onLike, onClick, onScrollToCenter, isActive, position }: SmoothScrollCardProps) {
     const variants = {
         prev2: {
             y: -200,
@@ -62,7 +63,13 @@ export function SmoothScrollCard({ candidate, isLiked, onLike, onClick, isActive
     return (
         <motion.div
             className="absolute w-full cursor-pointer"
-            onClick={onClick}
+            onClick={() => {
+                if (isActive) {
+                    onClick()
+                } else {
+                    onScrollToCenter()
+                }
+            }}
             initial={false}
             animate={position}
             variants={variants}
@@ -227,6 +234,7 @@ export function SmoothScrollList({ candidates, isUserLiked, onLike, onSelect }: 
                                     onLike(candidate)
                                 }}
                                 onClick={() => onSelect(candidate)}
+                                onScrollToCenter={() => setCurrentIndex(index)}
                                 isActive={index === currentIndex}
                                 position={position}
                             />

--- a/src/features/petmate/hooks/use-petmate.ts
+++ b/src/features/petmate/hooks/use-petmate.ts
@@ -200,6 +200,27 @@ export function usePetMate({ userId, initialFilter }: UsePetMateOptions) {
         }
     }, [userId, fetchMatches]);
 
+    // Cancel sent request (unlike)
+    const cancelRequest = useCallback(async (toUserId: number): Promise<boolean> => {
+        try {
+            const success = await petMateApi.unlike({ fromUserId: userId, toUserId });
+            if (success) {
+                // Remove from likedUserIds and refresh sent requests
+                setLikedUserIds(prev => {
+                    const newSet = new Set(prev);
+                    newSet.delete(toUserId);
+                    return newSet;
+                });
+                await fetchSentRequests();
+            }
+            return success;
+        } catch (err) {
+            console.error('Failed to cancel request:', err);
+            setError('요청 취소에 실패했습니다.');
+            return false;
+        }
+    }, [userId, fetchSentRequests]);
+
     // Initial fetch
     useEffect(() => {
         fetchCandidates(currentFilter);
@@ -239,5 +260,6 @@ export function usePetMate({ userId, initialFilter }: UsePetMateOptions) {
         sentRequests,
         fetchSentRequests,
         unfriend,
+        cancelRequest,
     };
 }

--- a/src/features/petmate/pages/PetMatePage.tsx
+++ b/src/features/petmate/pages/PetMatePage.tsx
@@ -76,6 +76,7 @@ export default function PetMatePage() {
     rejectRequest,
     updateOnlineStatus,
     unfriend,
+    cancelRequest,
   } = usePetMate({
     userId: user?.id ? Number(user.id) : 1,
     initialFilter: userCoords ? {
@@ -952,6 +953,7 @@ export default function PetMatePage() {
         onAccept={acceptRequest}
         onReject={rejectRequest}
         onUnfriend={unfriend}
+        onCancelRequest={cancelRequest}
         onMatchSuccess={(result, request) => {
           setMatchedUser({
             id: request.matchId,


### PR DESCRIPTION
## 📝 요약
좋아요 토글, 보낸 요청 취소 기능 추가 및 모달/스크롤 UX 개선

## 🛠️ 주요 변경 사항

### 기능 추가
| 기능 | 설명 |
|------|------|
| **요청 취소** | 보낸 요청 탭에서 "취소" 버튼으로 요청 취소 가능 |
| **좋아요 토글** | 좋아요 버튼 재클릭 시 요청 취소 |

### UI/UX 개선
| 항목 | 변경 내용 |
|------|----------|
| **모달 크기** | 높이 500px 고정 + 내부 스크롤 |
| **모달 터치 버그** | layoutId 제거로 모달 닫기 후 터치 문제 해결 |
| **SmoothScrollList** | 위/아래 카드 클릭 시 가운데로 스크롤 |
| **사이드바 버튼** | "받은 요청" → "매칭 친구" + Users 아이콘 |

## 📁 수정된 파일
- `src/features/petmate/hooks/use-petmate.ts`
- `src/features/petmate/components/MatchingFriendsModal.tsx`
- `src/features/petmate/components/SmoothScrollList.tsx`
- `src/features/petmate/pages/PetMatePage.tsx`

## ✅ 검증 항목
- [x] 보낸 요청 취소 기능 동작
- [x] 좋아요 토글 동작
- [x] 모달 크기 고정 및 스크롤
- [x] 모달 닫기 후 터치 정상 동작
- [x] 비활성 카드 클릭 시 가운데로 스크롤