### PR TITLE
[fix] 포토갤러리 S3 이미지 CORS 문제 해결

### DIFF
--- a/src/features/diary/pages/PortfolioPage.tsx
+++ b/src/features/diary/pages/PortfolioPage.tsx
@@ -290,8 +290,22 @@ export default function PortfolioPage() {
     // --- 5. Objects (Golden Spiral) ---
     const radius = 8
     const sphereMeshes: THREE.Mesh[] = []
-    const textureLoader = new THREE.TextureLoader()
-    textureLoader.crossOrigin = 'anonymous'; // [FIX] Allow CORS for S3 images
+
+    // Helper function to load texture with explicit CORS
+    const loadTextureWithCORS = (url: string): THREE.Texture => {
+      const texture = new THREE.Texture();
+      const img = new Image();
+      img.crossOrigin = 'anonymous'; // Set BEFORE src
+      img.onload = () => {
+        texture.image = img;
+        texture.needsUpdate = true;
+      };
+      img.onerror = () => {
+        console.warn('[Portfolio] Failed to load image:', url);
+      };
+      img.src = url;
+      return texture;
+    };
 
     // [MODIFIED] Use dynamic 'diaries' instead of static 'diaryPhotos'
     // If empty, maybe show nothing or wait? For now if empty, it just renders nothing but scene setup works.
@@ -303,8 +317,8 @@ export default function PortfolioPage() {
       const y = radius * Math.sin(phi) * Math.sin(theta)
       const z = radius * Math.cos(phi)
 
-      // [FIX] Load standard texture (Data URL works here too)
-      const texture = textureLoader.load(photo.src || "/placeholder.svg");
+      // [FIX] Load texture with explicit CORS setting
+      const texture = loadTextureWithCORS(photo.src || "/placeholder.svg");
 
       const geometry = new THREE.PlaneGeometry(2, 2.5)
       const material = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
## 📝 작업 요약
포토갤러리 페이지에서 S3 이미지가 CORS 에러로 로드되지 않는 문제를 해결했습니다.

---

## 🔍 문제 원인
- Three.js `TextureLoader`로 S3 이미지를 로드할 때 **CORS preflight (OPTIONS)** 요청 실패
- S3 CORS 설정에 `OPTIONS` 메서드가 없어서 preflight 요청이 403으로 거부됨

---
<img width="462" height="606" alt="스크린샷 2026-01-06 오후 4 40 23" src="https://github.com/user-attachments/assets/8b401d26-d30b-4228-a56b-8a55b50b5f80" />


## ✅ 해결 방법

### 1. S3 CORS 설정 수정 (인프라)
```json
{
    "AllowedMethods": ["GET", "HEAD", "OPTIONS"]
}